### PR TITLE
fix(play-random): fix broken APIs, rewrite autoplay, add context menu

### DIFF
--- a/play-random/README.md
+++ b/play-random/README.md
@@ -9,11 +9,12 @@ Hey there! Welcome to my second Spicetify gig – a seemingly pointless (again?)
 ## Install
 
 Copy `playRandom.mjs` into your [Spicetify](https://github.com/khanhas/spicetify-cli) extensions directory:
-| **Platform** | **Path** |
-|----------------|--------------------------------------------------------------------------------------|
-| **Linux** | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
-| **MacOS** | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions` |
-| **Windows** | `%appdata%\spicetify\Extensions\` |
+
+| **Platform** | **Path**                                                                             |
+| ------------ | ------------------------------------------------------------------------------------ |
+| **Linux**    | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
+| **MacOS**    | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
+| **Windows**  | `%appdata%\spicetify\Extensions\`                                                    |
 
 After putting the extension file into the correct folder, run the following command to install the extension or install through marketplace:
 
@@ -41,15 +42,37 @@ spicetify apply
 
 ## Usage
 
-- Simply install the extension and click the shuffle button/icon located on the top bar(mostly top-left).
-- After a brief moment, the app will play a random track, adding an element of surprise to your music experience.
-- Note: It will clear your current context queue, but any songs queued manually by you will remain. If all manually queued songs are played, similar songs to the randomly played track will line up and play if you have the "Autoplay" setting enabled.
+- Click the **shuffle button** on the top bar to play a random track from the target user's public playlists.
+- **Right-click** the shuffle button to open the **Settings** modal where you can:
+  - Toggle **Autoplay** (continuous random playback)
+  - Set a **target profile URI** (accepts `spotify:user:<id>` or a Spotify profile share link)
+  - Save or reset to the default profile (`thesoundsofspotify`)
+- **Right-click any user profile** in Spotify to see the **Play Random** context menu:
+  - **Play a random track** - immediately plays a random song from that user's playlists
+  - **Queue a random track** - silently fetches and adds a random song to your queue
+  - **Set as randomiser profile** - saves that user as the target for autoplay and hotkeys
+
+### Keyboard Shortcuts
+
+| Shortcut  | Action                 |
+| --------- | ---------------------- |
+| `Alt + R` | Play a random song     |
+| `Alt + A` | Toggle autoplay on/off |
+| `Alt + E` | Open settings modal    |
+
+### Autoplay
+
+When autoplay is enabled, the extension pre-fetches a random track and injects it into your queue. When it plays, a toast notification appears and the next track is automatically queued. Skipping songs or manually queuing tracks won't interfere - the random track simply stays in your queue until it's reached.
+
+> **Tip:** For the smoothest experience, avoid rapidly skipping songs while autoplay is on. One random track is always queued up - skipping too fast may briefly play a non-random song before the next one loads.
 
 [![Preview](preview.gif)](https://raw.githubusercontent.com/TechShivvy/spicetify-extensions/main/play-random/preview.gif)
 
 ## Credits
 
 - [Delusoire](https://github.com/Delusoire) for the optimization help!
+- [Hitesh1090](https://github.com/Hitesh1090) for intermidiate development and testing of the extension and autoplay feature!
+- [veryboringhwl](https://github.com/veryboringhwl) for the API migration help!
 
 ## More
 

--- a/play-random/playRandom.mjs
+++ b/play-random/playRandom.mjs
@@ -409,11 +409,10 @@ import random from "https://esm.sh/lodash.random";
             queuedTrack = null;
             prefetchAndQueue(targetUserUri, playingUri);
           } else if (queuedTrack) {
-            // User skipped to something else — remove old queued track, queue a new one
+            // User skipped to something else, but our track is still in the queue - leave it
             console.log(
-              "[Play Random][AUTO] User skipped, re-queuing a new track",
+              "[Play Random][AUTO] User skipped, queued track still in queue",
             );
-            prefetchAndQueue(targetUserUri, currentUri);
           } else {
             // No track queued (prefetch failed or first load) — queue one now
             console.log(

--- a/play-random/playRandom.mjs
+++ b/play-random/playRandom.mjs
@@ -7,7 +7,8 @@ import random from "https://esm.sh/lodash.random";
   }
 
   const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  const icon = (name) => `<svg role="img" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[name]}</svg>`;
+  const icon = (name) =>
+    `<svg role="img" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[name]}</svg>`;
 
   function styleBtn(btn, bgColor, hoverColor) {
     Object.assign(btn.style, {
@@ -25,342 +26,436 @@ import random from "https://esm.sh/lodash.random";
     btn.onmouseleave = () => (btn.style.backgroundColor = bgColor);
   }
 
-  const _PlayRandom = class {
-    static async fetchPlaylistsFromUser(userUri) {
-      try {
-        const userId = userUri.split(":")[2];
-        const initialResponse = await Spicetify.CosmosAsync.get(
-          `https://api.spotify.com/v1/users/${userId}/playlists?limit=1`
-        );
-        const totalPlaylists = initialResponse.total;
+  var playRandom = (() => {
+    // src/app.tsx
+    var _PlayRandom = class {
+      static async fetchPlaylistsFromUser(userUri) {
+        try {
+          const userId = userUri.split(":")[2];
+          const initialResponse =
+            await Spicetify.Platform.RequestBuilder.build()
+              .withHost("https://spclient.wg.spotify.com/user-profile-view/v3")
+              .withPath(`/profile/${userId}/playlists`)
+              .withQueryParameters({ limit: 1, offset: 0 })
+              .send();
 
-        if (totalPlaylists === 0) {
-          return { error: "this mf dont have no playlists." };
-        }
-        if (totalPlaylists <= 50) {
-          return { playlists: initialResponse };
-        } else {
+          const totalPlaylists =
+            initialResponse.body?.total_public_playlists_count || 0;
+
+          if (totalPlaylists === 0) {
+            return { error: "[Play Random] this mf dont have no playlists." };
+          }
           const randomOffset = random(totalPlaylists - 1);
-          const url = `https://api.spotify.com/v1/users/${userId}/playlists?limit=1&offset=${randomOffset}`;
-          const response = await Spicetify.CosmosAsync.get(url);
-          return { playlists: response };
+          if (randomOffset === 0) {
+            return { playlists: initialResponse.body };
+          }
+          const offsetResponse = await Spicetify.Platform.RequestBuilder.build()
+            .withHost("https://spclient.wg.spotify.com/user-profile-view/v3")
+            .withPath(`/profile/${userId}/playlists`)
+            .withQueryParameters({ limit: 1, offset: randomOffset })
+            .send();
+          return { playlists: offsetResponse.body };
+        } catch (error) {
+          return {
+            error:
+              "[Play Random] Sad Bruh - Error fetching data : " + error.message,
+          };
         }
-      } catch (error) {
-        return { error: "Sad Bruh - Error fetching data : " + error.message };
       }
-    }
 
-    static async fetchPlaylist(response) {
-      if (response.error) {
-        console.log(response.error);
-        return null;
-      }
-      try {
-        const items = response.playlists?.items;
-        if (!items || items.length === 0) {
-          console.error("No playlist items found in response");
-          Spicetify.showNotification("Playlist came back empty... weird flex but ok", true);
+      static async fetchPlaylist(response) {
+        if (response.error) {
+          console.log(response.error);
           return null;
         }
-        const playlistUri = sample(items).uri;
-        console.log("Random ahh Playlist URI:", playlistUri);
-        return playlistUri;
-      } catch (error) {
-        console.error("Error picking a playlist:", error);
-        Spicetify.showNotification("Couldn't grab a playlist. The vibes are off rn", true);
-        return null;
+        try {
+          const items = response.playlists?.public_playlists || [];
+          if (items.length === 0) {
+            console.error("[Play Random] No playlist items found in response");
+            Spicetify.showNotification(
+              "[Play Random] Playlist came back empty... weird flex but ok",
+              true,
+            );
+            return null;
+          }
+          const playlist = items[0];
+          const playlistUri = playlist?.uri;
+          const playlistName = playlist?.name || "Unknown Playlist";
+          if (!playlistUri) {
+            console.error("[Play Random] Playlist had no URI");
+            Spicetify.showNotification(
+              "[Play Random] Found a playlist but it has no URI. Cursed.",
+              true,
+            );
+            return null;
+          }
+          console.log(
+            `[Play Random] Playlist: "${playlistName}" (${playlistUri})`,
+          );
+          return { uri: playlistUri, name: playlistName };
+        } catch (error) {
+          console.error("[Play Random] Error picking a playlist:", error);
+          Spicetify.showNotification(
+            "[Play Random] Couldn't grab a playlist. The vibes are off rn",
+            true,
+          );
+          return null;
+        }
       }
-    }
 
-    static async fetchTracksFromPlaylist(uri) {
-      try {
-        const res = await Spicetify.CosmosAsync.get(
-          `sp://core-playlist/v1/playlist/${uri}/rows`,
-          { policy: { link: true } }
-        );
-        return res.rows.map((item) => item.link);
-      } catch (error) {
-        console.error("Failed to fetch tracks from playlist:", error);
-        Spicetify.showNotification(
-          sample([
-            "Couldn't fetch tracks from that playlist. It ghosted us.",
-            "Playlist said 'access denied' basically. Rude.",
-            "Tracks? What tracks? The playlist won't share.",
-          ]),
-          true
-        );
-        return null;
+      static async fetchTracksFromPlaylist(uri) {
+        try {
+          const res = await Spicetify.Platform.PlaylistAPI.getContents(uri);
+          return res.items
+            .filter((track) => track.isPlayable)
+            .map((track) => track.uri);
+        } catch (error) {
+          console.error(
+            "[Play Random] Failed to fetch tracks from playlist:",
+            error,
+          );
+          Spicetify.showNotification(
+            "[Play Random] " +
+              sample([
+                "Couldn't fetch tracks from that playlist. It ghosted us.",
+                "Playlist said 'access denied' basically. Rude.",
+                "Tracks? What tracks? The playlist won't share.",
+              ]),
+            true,
+          );
+          return null;
+        }
       }
-    }
 
-    static async doTheThing(userUri) {
-      try {
-        Spicetify.showNotification(
-          sample([
-            "Sit tight, my friend. The wheels of randomness are turning; your tune is in the making.",
-            "Chill, mate! Randomness is doing its thing, and your jam is on the way.",
-            "Hold on, buddy. The dice of randomness are rolling, and your song is in the works.",
-            "Hey, hang in there! The randomness wheel is spinning, searching up a track for you.",
-            "Hold on, pal! The chaos engine is at play; your jam is currently in the making.",
-          ])
-        );
-        const playlists = await _PlayRandom.fetchPlaylistsFromUser(userUri);
-        console.log(playlists);
-        const randomPlaylistUri = await _PlayRandom.fetchPlaylist(playlists);
-        if (randomPlaylistUri) {
-          const trackUris = await _PlayRandom.fetchTracksFromPlaylist(randomPlaylistUri);
-          console.log(trackUris);
-          if (trackUris && trackUris.length > 0) {
-            let randomTrackUri;
-            const maxAttempts = 10;
-            let attempts = 0;
-            let foundPlayable = false;
-            while (attempts < maxAttempts) {
-              attempts++;
-              randomTrackUri = sample(trackUris);
-              try {
-                const trackInfo = await Spicetify.CosmosAsync.get(
-                  `https://api.spotify.com/v1/tracks/${randomTrackUri.split(":")[2]}`
-                );
-                if (trackInfo.preview_url) {
-                  console.log("preview_url: ", trackInfo.preview_url);
-                  foundPlayable = true;
-                  break;
-                } else {
-                  console.error(`Attempt ${attempts}/${maxAttempts}: Chosen song not playable`);
+      static async doTheThing(userUri) {
+        try {
+          Spicetify.showNotification(
+            "[Play Random] " +
+              sample([
+                "Sit tight, my friend. The wheels of randomness are turning; your tune is in the making.",
+                "Chill, mate! Randomness is doing its thing, and your jam is on the way.",
+                "Hold on, buddy. The dice of randomness are rolling, and your song is in the works.",
+                "Hey, hang in there! The randomness wheel is spinning, searching up a track for you.",
+                "Hold on, pal! The chaos engine is at play; your jam is currently in the making.",
+              ]),
+          );
+          const playlists = await _PlayRandom.fetchPlaylistsFromUser(userUri);
+          console.log("[Play Random] Playlists response:", playlists);
+          const playlistResult = await _PlayRandom.fetchPlaylist(playlists);
+          if (playlistResult) {
+            const { uri: randomPlaylistUri, name: playlistName } =
+              playlistResult;
+            const trackUris =
+              await _PlayRandom.fetchTracksFromPlaylist(randomPlaylistUri);
+            console.log(
+              `[Play Random] Tracks from "${playlistName}":`,
+              trackUris,
+            );
+            if (trackUris && trackUris.length > 0) {
+              let randomTrackUri;
+              let trackName = "Unknown Track";
+              let artistName = "Unknown Artist";
+              const maxAttempts = 10;
+              let attempts = 0;
+              let foundPlayable = false;
+              while (attempts < maxAttempts) {
+                attempts++;
+                randomTrackUri = sample(trackUris);
+                try {
+                  const { getTrack } = Spicetify.GraphQL.Definitions;
+                  const trackData = await Spicetify.GraphQL.Request(getTrack, {
+                    uri: randomTrackUri,
+                  });
+                  const trackUnion = trackData?.data?.trackUnion;
+                  trackName = trackUnion?.name || "Unknown Track";
+                  artistName =
+                    trackUnion?.firstArtist?.items?.[0]?.profile?.name ||
+                    "Unknown Artist";
+                  if (trackUnion?.playability?.playable) {
+                    console.log(
+                      `[Play Random] Track playable: "${trackName}" by ${artistName} (${randomTrackUri})`,
+                    );
+                    foundPlayable = true;
+                    break;
+                  } else {
+                    console.error(
+                      `[Play Random] Attempt ${attempts}/${maxAttempts}: "${trackName}" by ${artistName} not playable`,
+                    );
+                    await delay(1000);
+                  }
+                } catch (error) {
+                  console.error(
+                    `[Play Random] Attempt ${attempts}/${maxAttempts}: Error Fetching Track:`,
+                    error,
+                  );
+                  Spicetify.showNotification(
+                    `[Play Random] Track check failed (${attempts}/${maxAttempts})... still looking`,
+                    true,
+                  );
                   await delay(1000);
                 }
-              } catch (error) {
-                console.error(`Attempt ${attempts}/${maxAttempts}: Error Fetching Track:`, error);
-                Spicetify.showNotification(`Track check failed (${attempts}/${maxAttempts})... still looking`, true);
-                await delay(1000);
               }
-            }
-            if (!foundPlayable) {
-              console.error("Max attempts reached, no playable track found");
-              Spicetify.showNotification(
-                sample([
-                  "Tried 10 songs and none of em work. Massive L.",
-                  "Bruh, 10 attempts and still nothing. The playlist is cooked.",
-                  "Gave it 10 shots, all duds. This playlist is cursed fr.",
-                ]),
-                true
+              if (!foundPlayable) {
+                console.error(
+                  "[Play Random] Max attempts reached, no playable track found",
+                );
+                Spicetify.showNotification(
+                  "[Play Random] " +
+                    sample([
+                      "Tried 10 songs and none of em work. Massive L.",
+                      "Bruh, 10 attempts and still nothing. The playlist is cooked.",
+                      "Gave it 10 shots, all duds. This playlist is cursed fr.",
+                    ]),
+                  true,
+                );
+                return;
+              }
+              console.log(
+                `[Play Random] Playing: "${trackName}" by ${artistName} from "${playlistName}" (${randomTrackUri})`,
               );
-              return;
-            }
-            console.log("Random ahh Track URI:", randomTrackUri);
-            try {
-              await Spicetify.Player.playUri(randomTrackUri);
-            } catch (playError) {
-              console.error("Failed to play track:", playError);
+              try {
+                await Spicetify.Player.playUri(randomTrackUri);
+              } catch (playError) {
+                console.error("[Play Random] Failed to play track:", playError);
+                Spicetify.showNotification(
+                  "[Play Random] " +
+                    sample([
+                      "Had the song but Spotify said nah. Try again?",
+                      "Found a banger but the player choked. Rip.",
+                      "Track was right there and playback just died on us.",
+                    ]),
+                  true,
+                );
+                return;
+              }
               Spicetify.showNotification(
-                sample([
-                  "Had the song but Spotify said nah. Try again?",
-                  "Found a banger but the player choked. Rip.",
-                  "Track was right there and playback just died on us.",
-                ]),
-                true
+                "[Play Random] " +
+                  sample([
+                    "There you have it!",
+                    "Here it is!",
+                    "Presenting...",
+                    "And here you have it!",
+                  ]),
               );
-              return;
+            } else {
+              console.log("[Play Random] No tracks :((((");
+              Spicetify.showNotification(
+                "[Play Random] No tracks in the chosen playlist. Ghost town vibes.",
+                true,
+              );
             }
+          } else if (playlists?.error) {
+            console.log("[Play Random]", playlists.error);
             Spicetify.showNotification(
-              "Play Random - " +
-                sample([
-                  "There you have it!",
-                  "Here it is!",
-                  "Presenting...",
-                  "And here you have it!",
-                ])
+              "[Play Random] " +
+                (playlists.error.startsWith("[Play Random] Sad Bruh")
+                  ? "Server threw a fit. Try again in a sec."
+                  : "No playlists in selected account. They're playlist-less."),
+              true,
             );
           } else {
-            console.log("No tracks :((((");
-            Spicetify.showNotification("No tracks in the chosen playlist. Ghost town vibes.", true);
+            Spicetify.showNotification(
+              "[Play Random] Something didn't click. Try again maybe?",
+              true,
+            );
           }
-        } else if (playlists?.error) {
-          console.log(playlists.error);
+        } catch (error) {
+          console.error("[Play Random] doTheThing exploded:", error);
           Spicetify.showNotification(
-            playlists.error.startsWith("Sad Bruh")
-              ? "Server threw a fit. Try again in a sec."
-              : "No playlists in selected account. They're playlist-less.",
-            true
+            "[Play Random] " +
+              sample([
+                "Welp, something went totally sideways. Try again?",
+                "The randomness machine broke. Give it another shot.",
+                "Bruh moment — the whole thing just crashed. My bad.",
+              ]),
+            true,
           );
-        } else {
-          Spicetify.showNotification("Something didn't click. Try again maybe?", true);
         }
-      } catch (error) {
-        console.error("doTheThing exploded:", error);
-        Spicetify.showNotification(
-          sample([
-            "Welp, something went totally sideways. Try again?",
-            "The randomness machine broke. Give it another shot.",
-            "Bruh moment — the whole thing just crashed. My bad.",
-          ]),
-          true
+      }
+
+      static async addButton() {
+        while (
+          !Spicetify.Topbar?.Button ||
+          !Spicetify.PopupModal?.display ||
+          !Spicetify.CosmosAsync ||
+          !Spicetify.Playbar
+        ) {
+          await delay(100);
+        }
+
+        let targetUserUri = "spotify:user:thesoundsofspotify";
+        let autoplayEnabled = false;
+        let lastTrackUri = null;
+
+        // Play Random button
+        new Spicetify.Topbar.Button(
+          "Play a Random Song",
+          icon("shuffle"),
+          async () => {
+            await _PlayRandom.doTheThing(targetUserUri);
+          },
+          false,
         );
-      }
-    }
 
-    static async addButton() {
-      while (
-        !Spicetify.Topbar?.Button ||
-        !Spicetify.PopupModal?.display ||
-        !Spicetify.CosmosAsync ||
-        !Spicetify.Playbar
-      ) {
-        await delay(100);
-      }
+        // Toggle Autoplay button
+        new Spicetify.Topbar.Button(
+          "Toggle Autoplay",
+          icon("play"),
+          () => {
+            autoplayEnabled = !autoplayEnabled;
+            Spicetify.showNotification(
+              autoplayEnabled
+                ? "[Play Random] Autoplay: ON"
+                : "[Play Random] Autoplay: OFF",
+            );
+          },
+          false,
+        );
 
-      let targetUserUri = "spotify:user:thesoundsofspotify";
-      let autoplayEnabled = false;
-      let lastTrackUri = null;
+        // Set Profile button
+        new Spicetify.Topbar.Button(
+          "Set Playlist Profile",
+          icon("edit"),
+          () => openPlaylistProfileModal(),
+          false,
+        );
 
-      // Play Random button
-      new Spicetify.Topbar.Button(
-        "Play a Random Song",
-        icon("shuffle"),
-        async () => {
-          await _PlayRandom.doTheThing(targetUserUri);
-        },
-        false
-      );
+        // Track end detection
+        setInterval(async () => {
+          if (
+            !autoplayEnabled ||
+            !Spicetify?.Player?.getProgress ||
+            !Spicetify?.Player?.getDuration
+          )
+            return;
 
-      // Toggle Autoplay button
-      new Spicetify.Topbar.Button(
-        "Toggle Autoplay",
-        icon("play"),
-        () => {
-          autoplayEnabled = !autoplayEnabled;
-          Spicetify.showNotification(
-            autoplayEnabled ? "Autoplay: ON" : "Autoplay: OFF"
-          );
-        },
-        false
-      );
+          const progress = Spicetify.Player.getProgress();
+          const duration = Spicetify.Player.getDuration();
+          const currentUri = Spicetify.Player.data?.item.uri;
 
-      // Set Profile button
-      new Spicetify.Topbar.Button(
-        "Set Playlist Profile",
-        icon("edit"),
-        () => openPlaylistProfileModal(),
-        false
-      );
+          console.log("[Play Random][AUTO] progress:", progress);
+          console.log("[Play Random][AUTO] duration:", duration);
+          console.log("[Play Random][AUTO] uri:", currentUri);
+          console.log("[Play Random][AUTO] lastTrackUri:", lastTrackUri);
 
-      // Track end detection
-      setInterval(async () => {
-        if (!autoplayEnabled || !Spicetify?.Player?.getProgress || !Spicetify?.Player?.getDuration) return;
+          if (!progress || !duration || !currentUri) return;
 
-        const progress = Spicetify.Player.getProgress();
-        const duration = Spicetify.Player.getDuration();
-        const currentUri = Spicetify.Player.data?.item.uri;
-
-        console.log("[AUTO] progress:", progress);
-        console.log("[AUTO] duration:", duration);
-        console.log("[AUTO] uri:", currentUri);
-        console.log("[AUTO] lastTrackUri:", lastTrackUri);
-
-        if (!progress || !duration || !currentUri) return;
-
-        if (progress >= duration - 1000 && currentUri !== lastTrackUri) {
-          console.log("[AUTO] Track finished. Triggering new random...");
-          Spicetify.Player.pause();
-          lastTrackUri = currentUri;
-          await _PlayRandom.doTheThing(targetUserUri);
-        }
-      }, 2000);
-
-      // Hotkeys with Alt
-      document.addEventListener("keydown", async (e) => {
-        if (e.altKey && e.key === "a") { // Alt + A: Toggle autoplay
-          autoplayEnabled = !autoplayEnabled;
-          Spicetify.showNotification(
-            `Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`
-          );
-        }
-
-        if (e.altKey && e.key === "r") { // Alt + R: Play random now
-          await _PlayRandom.doTheThing(targetUserUri);
-        }
-
-        if (e.altKey && e.key === "e") { // Alt + E: Open playlist URI modal
-          openPlaylistProfileModal();
-        }
-      });
-
-      // Modal function for setting playlist profile URI
-      function openPlaylistProfileModal() {
-        const modalContent = document.createElement("div");
-        Object.assign(modalContent.style, {
-          display: "flex",
-          flexDirection: "column",
-          gap: "10px",
-        });
-
-        const input = document.createElement("input");
-        input.type = "text";
-        input.placeholder = "spotify:user:your_username";
-        input.value = targetUserUri;
-        Object.assign(input.style, {
-          padding: "0.375rem 0.75rem",
-          borderRadius: "0.25rem",
-          border: "1px solid #ced4da",
-          backgroundColor: "#fff",
-          color: "#212529",
-          width: "100%",
-          boxSizing: "border-box",
-          fontSize: "1rem",
-          transition: "border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out",
-        });
-        input.onfocus = () => {
-          input.style.borderColor = "#80bdff";
-          input.style.outline = "0";
-          input.style.boxShadow = "0 0 0 0.2rem rgba(0,123,255,.25)";
-        };
-        input.onblur = () => {
-          input.style.borderColor = "#ced4da";
-          input.style.boxShadow = "none";
-        };
-
-        const saveBtn = document.createElement("button");
-        saveBtn.textContent = "Save";
-        styleBtn(saveBtn, "#1DB954", "#1e9548ff");
-        saveBtn.onclick = () => {
-          const val = input.value.trim();
-          if (/^spotify:user:[\w-]+$/.test(val)) {
-            targetUserUri = val;
-            Spicetify.showNotification("User URI updated!");
-            Spicetify.PopupModal.hide();
-          } else {
-            Spicetify.showNotification("Invalid URI. Format: spotify:user:<id>", true);
+          if (progress >= duration - 1000 && currentUri !== lastTrackUri) {
+            console.log(
+              "[Play Random][AUTO] Track finished. Triggering new random...",
+            );
+            Spicetify.Player.pause();
+            lastTrackUri = currentUri;
+            await _PlayRandom.doTheThing(targetUserUri);
           }
-        };
+        }, 2000);
 
-        const resetBtn = document.createElement("button");
-        resetBtn.textContent = "Reset to Default";
-        styleBtn(resetBtn, "#6c757d", "#5c636a");
-        resetBtn.onclick = () => {
-          input.value = "spotify:user:thesoundsofspotify";
-          targetUserUri = "spotify:user:thesoundsofspotify";
-          Spicetify.showNotification("Reset to default profile.");
-        };
+        // Hotkeys with Alt
+        document.addEventListener("keydown", async (e) => {
+          if (e.altKey && e.key === "a") {
+            // Alt + A: Toggle autoplay
+            autoplayEnabled = !autoplayEnabled;
+            Spicetify.showNotification(
+              `[Play Random] Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`,
+            );
+          }
 
-        modalContent.appendChild(input);
-        modalContent.appendChild(saveBtn);
-        modalContent.appendChild(resetBtn);
+          if (e.altKey && e.key === "r") {
+            // Alt + R: Play random now
+            await _PlayRandom.doTheThing(targetUserUri);
+          }
 
-        Spicetify.PopupModal.display({
-          title: "Set Playlist Profile URI",
-          content: modalContent,
+          if (e.altKey && e.key === "e") {
+            // Alt + E: Open playlist URI modal
+            openPlaylistProfileModal();
+          }
         });
-      }
-    }
-  };
-  var PlayRandom = _PlayRandom;
-  async function main() {
-    PlayRandom.addButton();
-  }
-  var app_default = main;
 
-  (async () => {
-    await app_default();
+        // Modal function for setting playlist profile URI
+        function openPlaylistProfileModal() {
+          const modalContent = document.createElement("div");
+          Object.assign(modalContent.style, {
+            display: "flex",
+            flexDirection: "column",
+            gap: "10px",
+          });
+
+          const input = document.createElement("input");
+          input.type = "text";
+          input.placeholder = "spotify:user:your_username";
+          input.value = targetUserUri;
+          Object.assign(input.style, {
+            padding: "0.375rem 0.75rem",
+            borderRadius: "0.25rem",
+            border: "1px solid #ced4da",
+            backgroundColor: "#fff",
+            color: "#212529",
+            width: "100%",
+            boxSizing: "border-box",
+            fontSize: "1rem",
+            transition:
+              "border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out",
+          });
+          input.onfocus = () => {
+            input.style.borderColor = "#80bdff";
+            input.style.outline = "0";
+            input.style.boxShadow = "0 0 0 0.2rem rgba(0,123,255,.25)";
+          };
+          input.onblur = () => {
+            input.style.borderColor = "#ced4da";
+            input.style.boxShadow = "none";
+          };
+
+          const saveBtn = document.createElement("button");
+          saveBtn.textContent = "Save";
+          styleBtn(saveBtn, "#1DB954", "#1e9548ff");
+          saveBtn.onclick = () => {
+            const val = input.value.trim();
+            if (/^spotify:user:[\w-]+$/.test(val)) {
+              targetUserUri = val;
+              Spicetify.showNotification("[Play Random] User URI updated!");
+              Spicetify.PopupModal.hide();
+            } else {
+              Spicetify.showNotification(
+                "[Play Random] Invalid URI. Format: spotify:user:<id>",
+                true,
+              );
+            }
+          };
+
+          const resetBtn = document.createElement("button");
+          resetBtn.textContent = "Reset to Default";
+          styleBtn(resetBtn, "#6c757d", "#5c636a");
+          resetBtn.onclick = () => {
+            input.value = "spotify:user:thesoundsofspotify";
+            targetUserUri = "spotify:user:thesoundsofspotify";
+            Spicetify.showNotification(
+              "[Play Random] Reset to default profile.",
+            );
+          };
+
+          modalContent.appendChild(input);
+          modalContent.appendChild(saveBtn);
+          modalContent.appendChild(resetBtn);
+
+          Spicetify.PopupModal.display({
+            title: "Set Playlist Profile URI",
+            content: modalContent,
+          });
+        }
+      }
+    };
+
+    var PlayRandom = _PlayRandom;
+
+    async function main() {
+      PlayRandom.addButton();
+    }
+
+    var app_default = main;
+
+    (async () => {
+      await app_default();
+    })();
   })();
 })();

--- a/play-random/playRandom.mjs
+++ b/play-random/playRandom.mjs
@@ -710,6 +710,76 @@ import random from "https://esm.sh/lodash.random";
             content: configContainer,
           });
         }
+
+        // Context menu on user profiles
+        const ctxPlayRandom = new Spicetify.ContextMenu.Item(
+          "Play a random track",
+          async (uris) => {
+            const userUri = uris[0];
+            await _PlayRandom.doTheThing(userUri);
+          },
+          undefined,
+          "play",
+        );
+
+        const ctxQueueRandom = new Spicetify.ContextMenu.Item(
+          "Queue a random track",
+          async (uris) => {
+            const userUri = uris[0];
+            Spicetify.showNotification(
+              "[Play Random] Fetching a random track to queue...",
+            );
+            const track = await _PlayRandom.fetchRandomTrack(
+              userUri,
+              Spicetify.Player.data?.item?.uri,
+            );
+            if (track) {
+              try {
+                await Spicetify.addToQueue([{ uri: track.uri }]);
+                Spicetify.showNotification(
+                  `[Play Random] Queued: "${track.trackName}" by ${track.artistName}`,
+                );
+              } catch (e) {
+                Spicetify.showNotification(
+                  "[Play Random] Failed to add to queue",
+                  true,
+                );
+              }
+            } else {
+              Spicetify.showNotification(
+                "[Play Random] Couldn't find a playable track from this user",
+                true,
+              );
+            }
+          },
+          undefined,
+          "queue",
+        );
+
+        const ctxSetProfile = new Spicetify.ContextMenu.Item(
+          "Set as randomiser profile",
+          (uris) => {
+            const userUri = uris[0];
+            targetUserUri = userUri;
+            LocalStorage.set("play-random:user-uri", userUri);
+            Spicetify.showNotification(
+              `[Play Random] Profile set to ${userUri.split(":")[2]}`,
+            );
+            if (autoplayEnabled) {
+              prefetchAndQueue(targetUserUri, Spicetify.Player.data?.item?.uri);
+            }
+          },
+          undefined,
+          "artist",
+        );
+
+        new Spicetify.ContextMenu.SubMenu(
+          "Play Random",
+          [ctxPlayRandom, ctxQueueRandom, ctxSetProfile],
+          (uris) => Spicetify.URI.isProfile(uris[0]),
+          false,
+          "shuffle",
+        ).register();
       }
     };
 

--- a/play-random/playRandom.mjs
+++ b/play-random/playRandom.mjs
@@ -274,21 +274,28 @@ import random from "https://esm.sh/lodash.random";
       }
 
       static async addButton() {
+        const { LocalStorage } = Spicetify;
+
         while (
           !Spicetify.Topbar?.Button ||
           !Spicetify.PopupModal?.display ||
-          !Spicetify.CosmosAsync ||
-          !Spicetify.Playbar
+          !Spicetify.Playbar ||
+          !LocalStorage
         ) {
           await delay(100);
         }
 
-        let targetUserUri = "spotify:user:thesoundsofspotify";
-        let autoplayEnabled = false;
+        const DEFAULT_URI = "spotify:user:thesoundsofspotify";
+
+        // Load persisted settings
+        let targetUserUri =
+          LocalStorage.get("play-random:user-uri") || DEFAULT_URI;
+        let autoplayEnabled =
+          LocalStorage.get("play-random:autoplay") === "true";
         let lastTrackUri = null;
 
-        // Play Random button
-        new Spicetify.Topbar.Button(
+        // Single topbar button — right click opens settings
+        const button = new Spicetify.Topbar.Button(
           "Play a Random Song",
           icon("shuffle"),
           async () => {
@@ -296,31 +303,12 @@ import random from "https://esm.sh/lodash.random";
           },
           false,
         );
+        button.element.oncontextmenu = (e) => {
+          e.preventDefault();
+          openSettings();
+        };
 
-        // Toggle Autoplay button
-        new Spicetify.Topbar.Button(
-          "Toggle Autoplay",
-          icon("play"),
-          () => {
-            autoplayEnabled = !autoplayEnabled;
-            Spicetify.showNotification(
-              autoplayEnabled
-                ? "[Play Random] Autoplay: ON"
-                : "[Play Random] Autoplay: OFF",
-            );
-          },
-          false,
-        );
-
-        // Set Profile button
-        new Spicetify.Topbar.Button(
-          "Set Playlist Profile",
-          icon("edit"),
-          () => openPlaylistProfileModal(),
-          false,
-        );
-
-        // Track end detection
+        // Track end detection for autoplay
         setInterval(async () => {
           if (
             !autoplayEnabled ||
@@ -353,94 +341,186 @@ import random from "https://esm.sh/lodash.random";
         // Hotkeys with Alt
         document.addEventListener("keydown", async (e) => {
           if (e.altKey && e.key === "a") {
-            // Alt + A: Toggle autoplay
             autoplayEnabled = !autoplayEnabled;
+            LocalStorage.set("play-random:autoplay", String(autoplayEnabled));
             Spicetify.showNotification(
               `[Play Random] Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`,
             );
           }
 
           if (e.altKey && e.key === "r") {
-            // Alt + R: Play random now
             await _PlayRandom.doTheThing(targetUserUri);
           }
 
           if (e.altKey && e.key === "e") {
-            // Alt + E: Open playlist URI modal
-            openPlaylistProfileModal();
+            openSettings();
           }
         });
 
-        // Modal function for setting playlist profile URI
-        function openPlaylistProfileModal() {
-          const modalContent = document.createElement("div");
-          Object.assign(modalContent.style, {
-            display: "flex",
-            flexDirection: "column",
-            gap: "10px",
+        // Settings modal (right-click menu)
+        let configContainer = null;
+
+        function openSettings() {
+          configContainer = document.createElement("div");
+          configContainer.id = "play-random-config";
+
+          const style = document.createElement("style");
+          style.textContent = `
+#play-random-config .setting-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+}
+#play-random-config .setting-row .col.description {
+  cursor: default;
+  width: 50%;
+}
+#play-random-config .setting-row .col.action {
+  display: flex;
+  justify-content: flex-end;
+  width: 50%;
+}
+#play-random-config button.switch {
+  align-items: center;
+  border: 0;
+  border-radius: 50%;
+  background-color: rgba(var(--spice-rgb-shadow), .7);
+  color: var(--spice-text);
+  cursor: pointer;
+  display: flex;
+  padding: 8px;
+}
+#play-random-config button.switch.disabled {
+  color: rgba(var(--spice-rgb-text), .3);
+}
+#play-random-config input {
+  width: 100%;
+  padding: 0 8px;
+  height: 32px;
+  border: 0;
+  border-radius: 4px;
+  background: rgba(var(--spice-rgb-shadow), .7);
+  color: var(--spice-text);
+  font-size: 0.875rem;
+}
+#play-random-config button.btn {
+  font-weight: 700;
+  background-color: rgba(var(--spice-rgb-shadow), .7);
+  border-radius: 500px;
+  transition-duration: 33ms;
+  transition-property: background-color, border-color, color, box-shadow, filter, transform;
+  padding-inline: 15px;
+  border: 1px solid #727272;
+  color: var(--spice-text);
+  min-block-size: 32px;
+  cursor: pointer;
+}
+#play-random-config button.btn:hover {
+  transform: scale(1.04);
+  border-color: var(--spice-text);
+}
+`;
+
+          // --- Autoplay toggle ---
+          const autoplayRow = document.createElement("div");
+          autoplayRow.classList.add("setting-row");
+          autoplayRow.innerHTML = `
+<label class="col description">Autoplay (continuous random)</label>
+<div class="col action">
+  <button class="switch ${autoplayEnabled ? "" : "disabled"}">
+    <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons.check}</svg>
+  </button>
+</div>`;
+          const autoplaySwitch = autoplayRow.querySelector("button.switch");
+          autoplaySwitch.onclick = () => {
+            autoplayEnabled = !autoplayEnabled;
+            autoplaySwitch.classList.toggle("disabled", !autoplayEnabled);
+            LocalStorage.set("play-random:autoplay", String(autoplayEnabled));
+            Spicetify.showNotification(
+              `[Play Random] Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`,
+            );
+          };
+
+          // --- Profile URI section ---
+          const profileHeader = document.createElement("h3");
+          profileHeader.textContent = "Playlist Profile URI";
+          profileHeader.style.marginTop = "16px";
+
+          const uriInput = document.createElement("input");
+          uriInput.type = "text";
+          uriInput.placeholder = "spotify:user:<id>";
+          uriInput.value = targetUserUri;
+
+          const hintText = document.createElement("span");
+          hintText.textContent =
+            "Tip: You can also paste a Spotify profile share link!";
+          Object.assign(hintText.style, {
+            fontSize: "0.75rem",
+            opacity: "0.6",
+            marginTop: "4px",
           });
 
-          const input = document.createElement("input");
-          input.type = "text";
-          input.placeholder = "spotify:user:your_username";
-          input.value = targetUserUri;
-          Object.assign(input.style, {
-            padding: "0.375rem 0.75rem",
-            borderRadius: "0.25rem",
-            border: "1px solid #ced4da",
-            backgroundColor: "#fff",
-            color: "#212529",
-            width: "100%",
-            boxSizing: "border-box",
-            fontSize: "1rem",
-            transition:
-              "border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out",
+          const buttonRow = document.createElement("div");
+          Object.assign(buttonRow.style, {
+            display: "flex",
+            gap: "8px",
+            marginTop: "8px",
           });
-          input.onfocus = () => {
-            input.style.borderColor = "#80bdff";
-            input.style.outline = "0";
-            input.style.boxShadow = "0 0 0 0.2rem rgba(0,123,255,.25)";
-          };
-          input.onblur = () => {
-            input.style.borderColor = "#ced4da";
-            input.style.boxShadow = "none";
-          };
 
           const saveBtn = document.createElement("button");
+          saveBtn.className = "btn";
           saveBtn.textContent = "Save";
-          styleBtn(saveBtn, "#1DB954", "#1e9548ff");
           saveBtn.onclick = () => {
-            const val = input.value.trim();
-            if (/^spotify:user:[\w-]+$/.test(val)) {
+            let val = uriInput.value.trim();
+            // Parse Spotify profile link to URI
+            const linkMatch = val.match(
+              /^https?:\/\/open\.spotify\.com\/user\/([\w.-]+)/,
+            );
+            if (linkMatch) {
+              val = `spotify:user:${linkMatch[1]}`;
+            }
+            if (/^spotify:user:[\w.-]+$/.test(val)) {
               targetUserUri = val;
-              Spicetify.showNotification("[Play Random] User URI updated!");
+              uriInput.value = val;
+              LocalStorage.set("play-random:user-uri", val);
+              Spicetify.showNotification("[Play Random] User URI saved!");
               Spicetify.PopupModal.hide();
             } else {
               Spicetify.showNotification(
-                "[Play Random] Invalid URI. Format: spotify:user:<id>",
+                "[Play Random] Invalid input. Use spotify:user:<id> or a Spotify profile link.",
                 true,
               );
             }
           };
 
           const resetBtn = document.createElement("button");
+          resetBtn.className = "btn";
           resetBtn.textContent = "Reset to Default";
-          styleBtn(resetBtn, "#6c757d", "#5c636a");
           resetBtn.onclick = () => {
-            input.value = "spotify:user:thesoundsofspotify";
-            targetUserUri = "spotify:user:thesoundsofspotify";
+            uriInput.value = DEFAULT_URI;
+            targetUserUri = DEFAULT_URI;
+            LocalStorage.set("play-random:user-uri", DEFAULT_URI);
             Spicetify.showNotification(
               "[Play Random] Reset to default profile.",
             );
           };
 
-          modalContent.appendChild(input);
-          modalContent.appendChild(saveBtn);
-          modalContent.appendChild(resetBtn);
+          buttonRow.appendChild(saveBtn);
+          buttonRow.appendChild(resetBtn);
+
+          configContainer.append(
+            style,
+            autoplayRow,
+            profileHeader,
+            uriInput,
+            hintText,
+            buttonRow,
+          );
 
           Spicetify.PopupModal.display({
-            title: "Set Playlist Profile URI",
-            content: modalContent,
+            title: "Play Random — Settings",
+            content: configContainer,
           });
         }
       }

--- a/play-random/playRandom.mjs
+++ b/play-random/playRandom.mjs
@@ -6,45 +6,95 @@ import random from "https://esm.sh/lodash.random";
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
 
-  var main = (() => {
-    // src/app.tsx
-    var _PlayRandom = class {
-      static async fetchPlaylistsFromUser(userUri) {
-        try {
-          const userId = userUri.split(":")[2];
-          const initialResponse = await Spicetify.CosmosAsync.get(
-            `https://api.spotify.com/v1/users/${userId}/playlists?limit=1`
-          );
-          const totalPlaylists = initialResponse.total;
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const icon = (name) => `<svg role="img" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[name]}</svg>`;
 
-          if (totalPlaylists == 0) {
-            return { error: "this mf dont have no playlists." };
-          }
-          if (totalPlaylists <= 50) {
-            return { playlists: initialResponse, from: "lesser" };
-          } else if (totalPlaylists > 50) {
-            const randomOffset = random(totalPlaylists - 1);
-            const url = `https://api.spotify.com/v1/users/${userId}/playlists?limit=1&offset=${randomOffset}`;
-            const response = await Spicetify.CosmosAsync.get(url);
-            return { playlists: response, from: "more" };
-          }
-        } catch (error) {
-          return { error: "Sad Bruh - Error fetching data : " + error.message };
+  function styleBtn(btn, bgColor, hoverColor) {
+    Object.assign(btn.style, {
+      backgroundColor: bgColor,
+      color: "#fff",
+      border: "none",
+      padding: "0.375rem 0.75rem",
+      borderRadius: "0.25rem",
+      fontSize: "1rem",
+      cursor: "pointer",
+      transition: "background-color 0.15s ease-in-out",
+    });
+    btn.className = "main-button-button";
+    btn.onmouseenter = () => (btn.style.backgroundColor = hoverColor);
+    btn.onmouseleave = () => (btn.style.backgroundColor = bgColor);
+  }
+
+  const _PlayRandom = class {
+    static async fetchPlaylistsFromUser(userUri) {
+      try {
+        const userId = userUri.split(":")[2];
+        const initialResponse = await Spicetify.CosmosAsync.get(
+          `https://api.spotify.com/v1/users/${userId}/playlists?limit=1`
+        );
+        const totalPlaylists = initialResponse.total;
+
+        if (totalPlaylists === 0) {
+          return { error: "this mf dont have no playlists." };
         }
-      }
-
-      static async fetchPlaylist(response) {
-        if (response.error) {
-          console.log(response.error);
-          return "nope";
+        if (totalPlaylists <= 50) {
+          return { playlists: initialResponse };
         } else {
-          const playlistUri = sample(response.playlists.items).uri;
-          console.log("Random ahh Playlist URI:", playlistUri);
-          return playlistUri;
+          const randomOffset = random(totalPlaylists - 1);
+          const url = `https://api.spotify.com/v1/users/${userId}/playlists?limit=1&offset=${randomOffset}`;
+          const response = await Spicetify.CosmosAsync.get(url);
+          return { playlists: response };
         }
+      } catch (error) {
+        return { error: "Sad Bruh - Error fetching data : " + error.message };
       }
+    }
 
-      static async doTheThing(userUri) {
+    static async fetchPlaylist(response) {
+      if (response.error) {
+        console.log(response.error);
+        return null;
+      }
+      try {
+        const items = response.playlists?.items;
+        if (!items || items.length === 0) {
+          console.error("No playlist items found in response");
+          Spicetify.showNotification("Playlist came back empty... weird flex but ok", true);
+          return null;
+        }
+        const playlistUri = sample(items).uri;
+        console.log("Random ahh Playlist URI:", playlistUri);
+        return playlistUri;
+      } catch (error) {
+        console.error("Error picking a playlist:", error);
+        Spicetify.showNotification("Couldn't grab a playlist. The vibes are off rn", true);
+        return null;
+      }
+    }
+
+    static async fetchTracksFromPlaylist(uri) {
+      try {
+        const res = await Spicetify.CosmosAsync.get(
+          `sp://core-playlist/v1/playlist/${uri}/rows`,
+          { policy: { link: true } }
+        );
+        return res.rows.map((item) => item.link);
+      } catch (error) {
+        console.error("Failed to fetch tracks from playlist:", error);
+        Spicetify.showNotification(
+          sample([
+            "Couldn't fetch tracks from that playlist. It ghosted us.",
+            "Playlist said 'access denied' basically. Rude.",
+            "Tracks? What tracks? The playlist won't share.",
+          ]),
+          true
+        );
+        return null;
+      }
+    }
+
+    static async doTheThing(userUri) {
+      try {
         Spicetify.showNotification(
           sample([
             "Sit tight, my friend. The wheels of randomness are turning; your tune is in the making.",
@@ -57,35 +107,62 @@ import random from "https://esm.sh/lodash.random";
         const playlists = await _PlayRandom.fetchPlaylistsFromUser(userUri);
         console.log(playlists);
         const randomPlaylistUri = await _PlayRandom.fetchPlaylist(playlists);
-        if (randomPlaylistUri !== "nope") {
-          const trackUris = await _PlayRandom.fetchTracksFromPlaylist(
-            randomPlaylistUri
-          );
+        if (randomPlaylistUri) {
+          const trackUris = await _PlayRandom.fetchTracksFromPlaylist(randomPlaylistUri);
           console.log(trackUris);
           if (trackUris && trackUris.length > 0) {
             let randomTrackUri;
-            while (true) {
+            const maxAttempts = 10;
+            let attempts = 0;
+            let foundPlayable = false;
+            while (attempts < maxAttempts) {
+              attempts++;
               randomTrackUri = sample(trackUris);
               try {
                 const trackInfo = await Spicetify.CosmosAsync.get(
-                  `https://api.spotify.com/v1/tracks/${
-                    randomTrackUri.split(":")[2]
-                  }`
+                  `https://api.spotify.com/v1/tracks/${randomTrackUri.split(":")[2]}`
                 );
                 if (trackInfo.preview_url) {
                   console.log("preview_url: ", trackInfo.preview_url);
+                  foundPlayable = true;
                   break;
                 } else {
-                  console.error("Chosen song not playable");
-                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                  console.error(`Attempt ${attempts}/${maxAttempts}: Chosen song not playable`);
+                  await delay(1000);
                 }
               } catch (error) {
-                console.error("Error Fetching Track: ", error);
-                await new Promise((resolve) => setTimeout(resolve, 1000));
+                console.error(`Attempt ${attempts}/${maxAttempts}: Error Fetching Track:`, error);
+                Spicetify.showNotification(`Track check failed (${attempts}/${maxAttempts})... still looking`, true);
+                await delay(1000);
               }
             }
+            if (!foundPlayable) {
+              console.error("Max attempts reached, no playable track found");
+              Spicetify.showNotification(
+                sample([
+                  "Tried 10 songs and none of em work. Massive L.",
+                  "Bruh, 10 attempts and still nothing. The playlist is cooked.",
+                  "Gave it 10 shots, all duds. This playlist is cursed fr.",
+                ]),
+                true
+              );
+              return;
+            }
             console.log("Random ahh Track URI:", randomTrackUri);
-            await Spicetify.Player.playUri(randomTrackUri);
+            try {
+              await Spicetify.Player.playUri(randomTrackUri);
+            } catch (playError) {
+              console.error("Failed to play track:", playError);
+              Spicetify.showNotification(
+                sample([
+                  "Had the song but Spotify said nah. Try again?",
+                  "Found a banger but the player choked. Rip.",
+                  "Track was right there and playback just died on us.",
+                ]),
+                true
+              );
+              return;
+            }
             Spicetify.showNotification(
               "Play Random - " +
                 sample([
@@ -97,213 +174,193 @@ import random from "https://esm.sh/lodash.random";
             );
           } else {
             console.log("No tracks :((((");
-            Spicetify.showNotification("No Tracks in the chosen playlist");
+            Spicetify.showNotification("No tracks in the chosen playlist. Ghost town vibes.", true);
           }
         } else if (playlists?.error) {
           console.log(playlists.error);
           Spicetify.showNotification(
             playlists.error.startsWith("Sad Bruh")
-              ? "Server Error"
-              : "No playlists in selected account"
+              ? "Server threw a fit. Try again in a sec."
+              : "No playlists in selected account. They're playlist-less.",
+            true
           );
+        } else {
+          Spicetify.showNotification("Something didn't click. Try again maybe?", true);
         }
+      } catch (error) {
+        console.error("doTheThing exploded:", error);
+        Spicetify.showNotification(
+          sample([
+            "Welp, something went totally sideways. Try again?",
+            "The randomness machine broke. Give it another shot.",
+            "Bruh moment — the whole thing just crashed. My bad.",
+          ]),
+          true
+        );
       }
-
-      // added more buttons
-      static async addButton() {
-        var _a, _b;
-        while (
-          !((_a = Spicetify.Topbar) == null ? void 0 : _a.Button) ||
-          !((_b = Spicetify.PopupModal) == null ? void 0 : _b.display) ||
-          !Spicetify.CosmosAsync ||
-          !Spicetify.Playbar
-        ) {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
-
-        let targetUserUri = "spotify:user:thesoundsofspotify"; 
-        let autoplayEnabled = false;
-        let lastTrackUri = null;
-
-        // Play Random button
-        new Spicetify.Topbar.Button(
-          "Play a Random Song",
-          `<svg role="img" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons.shuffle}</svg>`,
-          async () => {
-            await _PlayRandom.doTheThing(targetUserUri);
-          },
-          false
-        );
-
-        // Toggle Autoplay button
-        new Spicetify.Topbar.Button(
-          "Toggle Autoplay",
-          `<svg role="img" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons.play}</svg>`,
-          () => {
-            autoplayEnabled = !autoplayEnabled;
-            Spicetify.showNotification(
-              autoplayEnabled ? "Autoplay: ON" : "Autoplay: OFF"
-            );
-          },
-          false
-        );
-
-        // Set Profile button
-        new Spicetify.Topbar.Button(
-          "Set Playlist Profile",
-          `<svg role="img" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons.edit}</svg>`,
-          async () => {
-            openPlaylistProfileModal();
-          },
-          false
-        );
-
-        // Track end detection
-        setInterval(async () => {
-          if (!autoplayEnabled || !Spicetify?.Player?.getProgress || !Spicetify?.Player?.getDuration) return;
-
-          const progress = Spicetify.Player.getProgress();
-          const duration = Spicetify.Player.getDuration();
-          const currentUri = Spicetify.Player.data?.item.uri;
-
-          console.log("[AUTO] progress:", progress);
-          console.log("[AUTO] duration:", duration);
-          console.log("[AUTO] uri:", currentUri);
-          console.log("[AUTO] lastTrackUri:", lastTrackUri);
-
-          if (!progress || !duration || !currentUri) return;
-
-          if (progress >= duration - 1000 && currentUri !== lastTrackUri) {
-            console.log("[AUTO] Track finished. Triggering new random...");
-            Spicetify.Player.pause();
-            lastTrackUri = currentUri;
-            await _PlayRandom.doTheThing(targetUserUri);
-          }
-        }, 2000);
-
-        // Hotkeys with Alt instead of Ctrl
-        document.addEventListener("keydown", async (e) => {
-          if (e.altKey && e.key === "a") { // Alt + A: Toggle autoplay
-            autoplayEnabled = !autoplayEnabled;
-            Spicetify.showNotification(
-              `Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`
-            );
-          }
-
-          if (e.altKey && e.key === "r") { // Alt + R: Play random now
-            await _PlayRandom.doTheThing(targetUserUri);
-          }
-
-          if (e.altKey && e.key === "e") { // Alt + E: Open playlist URI modal
-            openPlaylistProfileModal();
-          }
-        });
-
-        // Modal function for setting playlist profile URI
-        function openPlaylistProfileModal() {
-          const modalContent = document.createElement("div");
-          modalContent.style.display = "flex";
-          modalContent.style.flexDirection = "column";
-          modalContent.style.gap = "10px";
-
-          const input = document.createElement("input");
-          input.type = "text";
-          input.placeholder = "spotify:user:your_username";
-          input.value = targetUserUri;
-          input.style.padding = "0.375rem 0.75rem";
-          input.style.borderRadius = "0.25rem";
-          input.style.border = "1px solid #ced4da";
-          input.style.backgroundColor = "#fff";
-          input.style.color = "#212529";
-          input.style.width = "100%";
-          input.style.boxSizing = "border-box";
-          input.style.fontSize = "1rem";
-          input.style.transition = "border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out";
-          input.onfocus = () => {
-            input.style.borderColor = "#80bdff";
-            input.style.outline = "0";
-            input.style.boxShadow = "0 0 0 0.2rem rgba(0,123,255,.25)";
-          };
-          input.onblur = () => {
-            input.style.borderColor = "#ced4da";
-            input.style.boxShadow = "none";
-          };
-
-          const saveBtn = document.createElement("button");
-          saveBtn.textContent = "Save";
-          saveBtn.className = "main-button-button";
-          saveBtn.style.backgroundColor = "#1DB954";
-          saveBtn.style.color = "#fff";
-          saveBtn.style.border = "none";
-          saveBtn.style.padding = "0.375rem 0.75rem";
-          saveBtn.style.borderRadius = "0.25rem";
-          saveBtn.style.fontSize = "1rem";
-          saveBtn.style.cursor = "pointer";
-          saveBtn.style.transition = "background-color 0.15s ease-in-out";
-          saveBtn.onmouseenter = () => (saveBtn.style.backgroundColor = "#1e9548ff");
-          saveBtn.onmouseleave = () => (saveBtn.style.backgroundColor = "#1DB954");
-          saveBtn.onclick = () => {
-            const val = input.value.trim();
-            if (/^spotify:user:[\w-]+$/.test(val)) {
-              targetUserUri = val;
-              Spicetify.showNotification("User URI updated!");
-              Spicetify.PopupModal.hide();
-            } else {
-              Spicetify.showNotification("Invalid URI. Format: spotify:user:<id>");
-            }
-          };
-
-          const resetBtn = document.createElement("button");
-          resetBtn.textContent = "Reset to Default";
-          resetBtn.className = "main-button-button";
-          resetBtn.style.backgroundColor = "#6c757d";
-          resetBtn.style.color = "#fff";
-          resetBtn.style.border = "none";
-          resetBtn.style.padding = "0.375rem 0.75rem";
-          resetBtn.style.borderRadius = "0.25rem";
-          resetBtn.style.fontSize = "1rem";
-          resetBtn.style.cursor = "pointer";
-          resetBtn.style.transition = "background-color 0.15s ease-in-out";
-          resetBtn.onmouseenter = () => (resetBtn.style.backgroundColor = "#5c636a");
-          resetBtn.onmouseleave = () => (resetBtn.style.backgroundColor = "#6c757d");
-          resetBtn.onclick = () => {
-            input.value = "spotify:user:thesoundsofspotify";
-            targetUserUri = "spotify:user:thesoundsofspotify";
-            Spicetify.showNotification("Reset to default profile.");
-          };
-
-          modalContent.appendChild(input);
-          modalContent.appendChild(saveBtn);
-          modalContent.appendChild(resetBtn);
-
-          Spicetify.PopupModal.display({
-            title: "Set Playlist Profile URI",
-            content: modalContent,
-          });
-        }
-      }
-    };
-
-    var PlayRandom = _PlayRandom;
-
-    PlayRandom.fetchTracksFromPlaylist = async (uri) => {
-      const res = await Spicetify.CosmosAsync.get(
-        `sp://core-playlist/v1/playlist/${uri}/rows`,
-        {
-          policy: { link: true },
-        }
-      );
-      return res.rows.map((item) => item.link);
-    };
-
-    async function main() {
-      PlayRandom.addButton();
     }
 
-    var app_default = main;
+    static async addButton() {
+      while (
+        !Spicetify.Topbar?.Button ||
+        !Spicetify.PopupModal?.display ||
+        !Spicetify.CosmosAsync ||
+        !Spicetify.Playbar
+      ) {
+        await delay(100);
+      }
 
-    (async () => {
-      await app_default();
-    })();
+      let targetUserUri = "spotify:user:thesoundsofspotify";
+      let autoplayEnabled = false;
+      let lastTrackUri = null;
+
+      // Play Random button
+      new Spicetify.Topbar.Button(
+        "Play a Random Song",
+        icon("shuffle"),
+        async () => {
+          await _PlayRandom.doTheThing(targetUserUri);
+        },
+        false
+      );
+
+      // Toggle Autoplay button
+      new Spicetify.Topbar.Button(
+        "Toggle Autoplay",
+        icon("play"),
+        () => {
+          autoplayEnabled = !autoplayEnabled;
+          Spicetify.showNotification(
+            autoplayEnabled ? "Autoplay: ON" : "Autoplay: OFF"
+          );
+        },
+        false
+      );
+
+      // Set Profile button
+      new Spicetify.Topbar.Button(
+        "Set Playlist Profile",
+        icon("edit"),
+        () => openPlaylistProfileModal(),
+        false
+      );
+
+      // Track end detection
+      setInterval(async () => {
+        if (!autoplayEnabled || !Spicetify?.Player?.getProgress || !Spicetify?.Player?.getDuration) return;
+
+        const progress = Spicetify.Player.getProgress();
+        const duration = Spicetify.Player.getDuration();
+        const currentUri = Spicetify.Player.data?.item.uri;
+
+        console.log("[AUTO] progress:", progress);
+        console.log("[AUTO] duration:", duration);
+        console.log("[AUTO] uri:", currentUri);
+        console.log("[AUTO] lastTrackUri:", lastTrackUri);
+
+        if (!progress || !duration || !currentUri) return;
+
+        if (progress >= duration - 1000 && currentUri !== lastTrackUri) {
+          console.log("[AUTO] Track finished. Triggering new random...");
+          Spicetify.Player.pause();
+          lastTrackUri = currentUri;
+          await _PlayRandom.doTheThing(targetUserUri);
+        }
+      }, 2000);
+
+      // Hotkeys with Alt
+      document.addEventListener("keydown", async (e) => {
+        if (e.altKey && e.key === "a") { // Alt + A: Toggle autoplay
+          autoplayEnabled = !autoplayEnabled;
+          Spicetify.showNotification(
+            `Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`
+          );
+        }
+
+        if (e.altKey && e.key === "r") { // Alt + R: Play random now
+          await _PlayRandom.doTheThing(targetUserUri);
+        }
+
+        if (e.altKey && e.key === "e") { // Alt + E: Open playlist URI modal
+          openPlaylistProfileModal();
+        }
+      });
+
+      // Modal function for setting playlist profile URI
+      function openPlaylistProfileModal() {
+        const modalContent = document.createElement("div");
+        Object.assign(modalContent.style, {
+          display: "flex",
+          flexDirection: "column",
+          gap: "10px",
+        });
+
+        const input = document.createElement("input");
+        input.type = "text";
+        input.placeholder = "spotify:user:your_username";
+        input.value = targetUserUri;
+        Object.assign(input.style, {
+          padding: "0.375rem 0.75rem",
+          borderRadius: "0.25rem",
+          border: "1px solid #ced4da",
+          backgroundColor: "#fff",
+          color: "#212529",
+          width: "100%",
+          boxSizing: "border-box",
+          fontSize: "1rem",
+          transition: "border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out",
+        });
+        input.onfocus = () => {
+          input.style.borderColor = "#80bdff";
+          input.style.outline = "0";
+          input.style.boxShadow = "0 0 0 0.2rem rgba(0,123,255,.25)";
+        };
+        input.onblur = () => {
+          input.style.borderColor = "#ced4da";
+          input.style.boxShadow = "none";
+        };
+
+        const saveBtn = document.createElement("button");
+        saveBtn.textContent = "Save";
+        styleBtn(saveBtn, "#1DB954", "#1e9548ff");
+        saveBtn.onclick = () => {
+          const val = input.value.trim();
+          if (/^spotify:user:[\w-]+$/.test(val)) {
+            targetUserUri = val;
+            Spicetify.showNotification("User URI updated!");
+            Spicetify.PopupModal.hide();
+          } else {
+            Spicetify.showNotification("Invalid URI. Format: spotify:user:<id>", true);
+          }
+        };
+
+        const resetBtn = document.createElement("button");
+        resetBtn.textContent = "Reset to Default";
+        styleBtn(resetBtn, "#6c757d", "#5c636a");
+        resetBtn.onclick = () => {
+          input.value = "spotify:user:thesoundsofspotify";
+          targetUserUri = "spotify:user:thesoundsofspotify";
+          Spicetify.showNotification("Reset to default profile.");
+        };
+
+        modalContent.appendChild(input);
+        modalContent.appendChild(saveBtn);
+        modalContent.appendChild(resetBtn);
+
+        Spicetify.PopupModal.display({
+          title: "Set Playlist Profile URI",
+          content: modalContent,
+        });
+      }
+    }
+  };
+  var PlayRandom = _PlayRandom;
+  async function main() {
+    PlayRandom.addButton();
+  }
+  var app_default = main;
+
+  (async () => {
+    await app_default();
   })();
 })();

--- a/play-random/playRandom.mjs
+++ b/play-random/playRandom.mjs
@@ -10,22 +10,6 @@ import random from "https://esm.sh/lodash.random";
   const icon = (name) =>
     `<svg role="img" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[name]}</svg>`;
 
-  function styleBtn(btn, bgColor, hoverColor) {
-    Object.assign(btn.style, {
-      backgroundColor: bgColor,
-      color: "#fff",
-      border: "none",
-      padding: "0.375rem 0.75rem",
-      borderRadius: "0.25rem",
-      fontSize: "1rem",
-      cursor: "pointer",
-      transition: "background-color 0.15s ease-in-out",
-    });
-    btn.className = "main-button-button";
-    btn.onmouseenter = () => (btn.style.backgroundColor = hoverColor);
-    btn.onmouseleave = () => (btn.style.backgroundColor = bgColor);
-  }
-
   var playRandom = (() => {
     // src/app.tsx
     var _PlayRandom = class {
@@ -63,7 +47,7 @@ import random from "https://esm.sh/lodash.random";
         }
       }
 
-      static async fetchPlaylist(response) {
+      static async fetchPlaylist(response, silent = false) {
         if (response.error) {
           console.log(response.error);
           return null;
@@ -72,10 +56,11 @@ import random from "https://esm.sh/lodash.random";
           const items = response.playlists?.public_playlists || [];
           if (items.length === 0) {
             console.error("[Play Random] No playlist items found in response");
-            Spicetify.showNotification(
-              "[Play Random] Playlist came back empty... weird flex but ok",
-              true,
-            );
+            if (!silent)
+              Spicetify.showNotification(
+                "[Play Random] Playlist came back empty... weird flex but ok",
+                true,
+              );
             return null;
           }
           const playlist = items[0];
@@ -83,10 +68,11 @@ import random from "https://esm.sh/lodash.random";
           const playlistName = playlist?.name || "Unknown Playlist";
           if (!playlistUri) {
             console.error("[Play Random] Playlist had no URI");
-            Spicetify.showNotification(
-              "[Play Random] Found a playlist but it has no URI. Cursed.",
-              true,
-            );
+            if (!silent)
+              Spicetify.showNotification(
+                "[Play Random] Found a playlist but it has no URI. Cursed.",
+                true,
+              );
             return null;
           }
           console.log(
@@ -95,15 +81,16 @@ import random from "https://esm.sh/lodash.random";
           return { uri: playlistUri, name: playlistName };
         } catch (error) {
           console.error("[Play Random] Error picking a playlist:", error);
-          Spicetify.showNotification(
-            "[Play Random] Couldn't grab a playlist. The vibes are off rn",
-            true,
-          );
+          if (!silent)
+            Spicetify.showNotification(
+              "[Play Random] Couldn't grab a playlist. The vibes are off rn",
+              true,
+            );
           return null;
         }
       }
 
-      static async fetchTracksFromPlaylist(uri) {
+      static async fetchTracksFromPlaylist(uri, silent = false) {
         try {
           const res = await Spicetify.Platform.PlaylistAPI.getContents(uri);
           return res.items
@@ -114,17 +101,134 @@ import random from "https://esm.sh/lodash.random";
             "[Play Random] Failed to fetch tracks from playlist:",
             error,
           );
-          Spicetify.showNotification(
-            "[Play Random] " +
-              sample([
-                "Couldn't fetch tracks from that playlist. It ghosted us.",
-                "Playlist said 'access denied' basically. Rude.",
-                "Tracks? What tracks? The playlist won't share.",
-              ]),
-            true,
-          );
+          if (!silent)
+            Spicetify.showNotification(
+              "[Play Random] " +
+                sample([
+                  "Couldn't fetch tracks from that playlist. It ghosted us.",
+                  "Playlist said 'access denied' basically. Rude.",
+                  "Tracks? What tracks? The playlist won't share.",
+                ]),
+              true,
+            );
           return null;
         }
+      }
+
+      // Silent background fetch — no toasts, returns track info or null
+      // Retries up to 3 different playlists if a playlist yields no playable tracks
+      static async fetchRandomTrack(userUri, excludeUri = null) {
+        const maxPlaylistAttempts = 3;
+
+        for (
+          let playlistAttempt = 1;
+          playlistAttempt <= maxPlaylistAttempts;
+          playlistAttempt++
+        ) {
+          try {
+            const playlists = await _PlayRandom.fetchPlaylistsFromUser(userUri);
+            if (playlists.error) {
+              console.log(
+                "[Play Random][PRE] Playlist fetch error:",
+                playlists.error,
+              );
+              return null; // User has 0 playlists or API error — no point retrying
+            }
+
+            const playlistResult = await _PlayRandom.fetchPlaylist(
+              playlists,
+              true,
+            );
+            if (!playlistResult) {
+              console.log(
+                `[Play Random][PRE] Playlist attempt ${playlistAttempt}/${maxPlaylistAttempts}: No playlist found, trying another`,
+              );
+              continue;
+            }
+
+            const { uri: playlistUri, name: playlistName } = playlistResult;
+            const trackUris = await _PlayRandom.fetchTracksFromPlaylist(
+              playlistUri,
+              true,
+            );
+            if (!trackUris || trackUris.length === 0) {
+              console.log(
+                `[Play Random][PRE] Playlist attempt ${playlistAttempt}/${maxPlaylistAttempts}: No tracks in "${playlistName}", trying another`,
+              );
+              continue;
+            }
+
+            const maxAttempts = 10;
+            const maxSameTrackRetries = 5;
+            let sameTrackCount = 0;
+            let foundTrack = false;
+
+            for (let attempts = 1; attempts <= maxAttempts; attempts++) {
+              const candidateUri = sample(trackUris);
+
+              // Avoid same track as currently playing (up to 5 retries)
+              if (
+                excludeUri &&
+                candidateUri === excludeUri &&
+                sameTrackCount < maxSameTrackRetries
+              ) {
+                sameTrackCount++;
+                console.log(
+                  `[Play Random][PRE] Same track as current (${sameTrackCount}/${maxSameTrackRetries}), retrying...`,
+                );
+                continue;
+              }
+
+              try {
+                const { getTrack } = Spicetify.GraphQL.Definitions;
+                const trackData = await Spicetify.GraphQL.Request(getTrack, {
+                  uri: candidateUri,
+                });
+                const trackUnion = trackData?.data?.trackUnion;
+                const trackName = trackUnion?.name || "Unknown Track";
+                const artistName =
+                  trackUnion?.firstArtist?.items?.[0]?.profile?.name ||
+                  "Unknown Artist";
+
+                if (trackUnion?.playability?.playable) {
+                  console.log(
+                    `[Play Random][PRE] Found: "${trackName}" by ${artistName} from "${playlistName}" (${candidateUri})`,
+                  );
+                  return {
+                    uri: candidateUri,
+                    trackName,
+                    artistName,
+                    playlistName,
+                  };
+                }
+                console.log(
+                  `[Play Random][PRE] Attempt ${attempts}/${maxAttempts}: "${trackName}" not playable`,
+                );
+                await delay(500);
+              } catch (error) {
+                console.error(
+                  `[Play Random][PRE] Attempt ${attempts}/${maxAttempts}: Error:`,
+                  error,
+                );
+                await delay(500);
+              }
+            }
+
+            console.log(
+              `[Play Random][PRE] Playlist attempt ${playlistAttempt}/${maxPlaylistAttempts}: All ${maxAttempts} track attempts failed in "${playlistName}", trying another playlist`,
+            );
+          } catch (error) {
+            console.error(
+              `[Play Random][PRE] Playlist attempt ${playlistAttempt}/${maxPlaylistAttempts} failed:`,
+              error,
+            );
+          }
+        }
+
+        console.log(
+          "[Play Random][PRE] All playlist attempts exhausted, no track found",
+        );
+        return null;
       }
 
       static async doTheThing(userUri) {
@@ -139,126 +243,53 @@ import random from "https://esm.sh/lodash.random";
                 "Hold on, pal! The chaos engine is at play; your jam is currently in the making.",
               ]),
           );
-          const playlists = await _PlayRandom.fetchPlaylistsFromUser(userUri);
-          console.log("[Play Random] Playlists response:", playlists);
-          const playlistResult = await _PlayRandom.fetchPlaylist(playlists);
-          if (playlistResult) {
-            const { uri: randomPlaylistUri, name: playlistName } =
-              playlistResult;
-            const trackUris =
-              await _PlayRandom.fetchTracksFromPlaylist(randomPlaylistUri);
-            console.log(
-              `[Play Random] Tracks from "${playlistName}":`,
-              trackUris,
-            );
-            if (trackUris && trackUris.length > 0) {
-              let randomTrackUri;
-              let trackName = "Unknown Track";
-              let artistName = "Unknown Artist";
-              const maxAttempts = 10;
-              let attempts = 0;
-              let foundPlayable = false;
-              while (attempts < maxAttempts) {
-                attempts++;
-                randomTrackUri = sample(trackUris);
-                try {
-                  const { getTrack } = Spicetify.GraphQL.Definitions;
-                  const trackData = await Spicetify.GraphQL.Request(getTrack, {
-                    uri: randomTrackUri,
-                  });
-                  const trackUnion = trackData?.data?.trackUnion;
-                  trackName = trackUnion?.name || "Unknown Track";
-                  artistName =
-                    trackUnion?.firstArtist?.items?.[0]?.profile?.name ||
-                    "Unknown Artist";
-                  if (trackUnion?.playability?.playable) {
-                    console.log(
-                      `[Play Random] Track playable: "${trackName}" by ${artistName} (${randomTrackUri})`,
-                    );
-                    foundPlayable = true;
-                    break;
-                  } else {
-                    console.error(
-                      `[Play Random] Attempt ${attempts}/${maxAttempts}: "${trackName}" by ${artistName} not playable`,
-                    );
-                    await delay(1000);
-                  }
-                } catch (error) {
-                  console.error(
-                    `[Play Random] Attempt ${attempts}/${maxAttempts}: Error Fetching Track:`,
-                    error,
-                  );
-                  Spicetify.showNotification(
-                    `[Play Random] Track check failed (${attempts}/${maxAttempts})... still looking`,
-                    true,
-                  );
-                  await delay(1000);
-                }
-              }
-              if (!foundPlayable) {
-                console.error(
-                  "[Play Random] Max attempts reached, no playable track found",
-                );
-                Spicetify.showNotification(
-                  "[Play Random] " +
-                    sample([
-                      "Tried 10 songs and none of em work. Massive L.",
-                      "Bruh, 10 attempts and still nothing. The playlist is cooked.",
-                      "Gave it 10 shots, all duds. This playlist is cursed fr.",
-                    ]),
-                  true,
-                );
-                return;
-              }
-              console.log(
-                `[Play Random] Playing: "${trackName}" by ${artistName} from "${playlistName}" (${randomTrackUri})`,
-              );
-              try {
-                await Spicetify.Player.playUri(randomTrackUri);
-              } catch (playError) {
-                console.error("[Play Random] Failed to play track:", playError);
-                Spicetify.showNotification(
-                  "[Play Random] " +
-                    sample([
-                      "Had the song but Spotify said nah. Try again?",
-                      "Found a banger but the player choked. Rip.",
-                      "Track was right there and playback just died on us.",
-                    ]),
-                  true,
-                );
-                return;
-              }
-              Spicetify.showNotification(
-                "[Play Random] " +
-                  sample([
-                    "There you have it!",
-                    "Here it is!",
-                    "Presenting...",
-                    "And here you have it!",
-                  ]),
-              );
-            } else {
-              console.log("[Play Random] No tracks :((((");
-              Spicetify.showNotification(
-                "[Play Random] No tracks in the chosen playlist. Ghost town vibes.",
-                true,
-              );
-            }
-          } else if (playlists?.error) {
-            console.log("[Play Random]", playlists.error);
+
+          const currentUri = Spicetify.Player.data?.item?.uri;
+          const track = await _PlayRandom.fetchRandomTrack(userUri, currentUri);
+
+          if (!track) {
             Spicetify.showNotification(
               "[Play Random] " +
-                (playlists.error.startsWith("[Play Random] Sad Bruh")
-                  ? "Server threw a fit. Try again in a sec."
-                  : "No playlists in selected account. They're playlist-less."),
+                sample([
+                  "Couldn't find anything playable. The universe said no.",
+                  "Struck out on finding a track. Try again?",
+                  "Came up empty. Maybe change the profile?",
+                ]),
               true,
             );
-          } else {
-            Spicetify.showNotification(
-              "[Play Random] Something didn't click. Try again maybe?",
-              true,
-            );
+            return null;
           }
+
+          console.log(
+            `[Play Random] Playing: "${track.trackName}" by ${track.artistName} from "${track.playlistName}" (${track.uri})`,
+          );
+
+          try {
+            await Spicetify.Player.playUri(track.uri);
+          } catch (playError) {
+            console.error("[Play Random] Failed to play track:", playError);
+            Spicetify.showNotification(
+              "[Play Random] " +
+                sample([
+                  "Had the song but Spotify said nah. Try again?",
+                  "Found a banger but the player choked. Rip.",
+                  "Track was right there and playback just died on us.",
+                ]),
+              true,
+            );
+            return null;
+          }
+
+          Spicetify.showNotification(
+            "[Play Random] " +
+              sample([
+                "There you have it!",
+                "Here it is!",
+                "Presenting...",
+                "And here you have it!",
+              ]),
+          );
+          return track;
         } catch (error) {
           console.error("[Play Random] doTheThing exploded:", error);
           Spicetify.showNotification(
@@ -266,10 +297,11 @@ import random from "https://esm.sh/lodash.random";
               sample([
                 "Welp, something went totally sideways. Try again?",
                 "The randomness machine broke. Give it another shot.",
-                "Bruh moment — the whole thing just crashed. My bad.",
+                "Bruh moment - the whole thing just crashed. My bad.",
               ]),
             true,
           );
+          return null;
         }
       }
 
@@ -292,14 +324,59 @@ import random from "https://esm.sh/lodash.random";
           LocalStorage.get("play-random:user-uri") || DEFAULT_URI;
         let autoplayEnabled =
           LocalStorage.get("play-random:autoplay") === "true";
-        let lastTrackUri = null;
+
+        // Autoplay state — prefetch + immediate queue injection
+        let queuedTrack = null;
+        let isPrefetching = false;
+
+        async function prefetchAndQueue(userUri, excludeUri = null) {
+          if (isPrefetching) return;
+          isPrefetching = true;
+          try {
+            // Remove previously queued track if we're replacing it
+            if (queuedTrack) {
+              try {
+                await Spicetify.removeFromQueue([{ uri: queuedTrack.uri }]);
+                console.log(
+                  `[Play Random][AUTO] Removed old queued track: "${queuedTrack.trackName}"`,
+                );
+              } catch (e) {
+                // Ignore — track may have already played or been removed
+              }
+              queuedTrack = null;
+            }
+
+            const track = await _PlayRandom.fetchRandomTrack(
+              userUri,
+              excludeUri,
+            );
+            if (track) {
+              try {
+                await Spicetify.addToQueue([{ uri: track.uri }]);
+                queuedTrack = track;
+                console.log(
+                  `[Play Random][AUTO] Queued: "${track.trackName}" by ${track.artistName}`,
+                );
+              } catch (e) {
+                console.error("[Play Random][AUTO] Failed to add to queue:", e);
+              }
+            } else {
+              console.log("[Play Random][AUTO] Pre-fetch came back empty");
+            }
+          } finally {
+            isPrefetching = false;
+          }
+        }
 
         // Single topbar button — right click opens settings
         const button = new Spicetify.Topbar.Button(
           "Play a Random Song",
           icon("shuffle"),
           async () => {
-            await _PlayRandom.doTheThing(targetUserUri);
+            const result = await _PlayRandom.doTheThing(targetUserUri);
+            if (autoplayEnabled && result) {
+              prefetchAndQueue(targetUserUri, result.uri);
+            }
           },
           false,
         );
@@ -308,35 +385,49 @@ import random from "https://esm.sh/lodash.random";
           openSettings();
         };
 
-        // Track end detection for autoplay
-        setInterval(async () => {
-          if (
-            !autoplayEnabled ||
-            !Spicetify?.Player?.getProgress ||
-            !Spicetify?.Player?.getDuration
-          )
-            return;
+        // Songchange listener — detect when our track plays, then queue the next one
+        Spicetify.Player.addEventListener("songchange", async () => {
+          if (!autoplayEnabled) return;
 
-          const progress = Spicetify.Player.getProgress();
-          const duration = Spicetify.Player.getDuration();
-          const currentUri = Spicetify.Player.data?.item.uri;
+          const currentUri = Spicetify.Player.data?.item?.uri;
 
-          console.log("[Play Random][AUTO] progress:", progress);
-          console.log("[Play Random][AUTO] duration:", duration);
-          console.log("[Play Random][AUTO] uri:", currentUri);
-          console.log("[Play Random][AUTO] lastTrackUri:", lastTrackUri);
-
-          if (!progress || !duration || !currentUri) return;
-
-          if (progress >= duration - 1000 && currentUri !== lastTrackUri) {
+          if (queuedTrack && currentUri === queuedTrack.uri) {
+            // Our queued track is now playing
             console.log(
-              "[Play Random][AUTO] Track finished. Triggering new random...",
+              `[Play Random][AUTO] Now playing: "${queuedTrack.trackName}" by ${queuedTrack.artistName}`,
             );
-            Spicetify.Player.pause();
-            lastTrackUri = currentUri;
-            await _PlayRandom.doTheThing(targetUserUri);
+            Spicetify.showNotification(
+              "[Play Random] " +
+                sample([
+                  "There you have it!",
+                  "Here it is!",
+                  "Presenting...",
+                  "And here you have it!",
+                ]),
+            );
+            const playingUri = queuedTrack.uri;
+            queuedTrack = null;
+            prefetchAndQueue(targetUserUri, playingUri);
+          } else if (queuedTrack) {
+            // User skipped to something else — remove old queued track, queue a new one
+            console.log(
+              "[Play Random][AUTO] User skipped, re-queuing a new track",
+            );
+            prefetchAndQueue(targetUserUri, currentUri);
+          } else {
+            // No track queued (prefetch failed or first load) — queue one now
+            console.log(
+              "[Play Random][AUTO] No queued track, fetching one now",
+            );
+            prefetchAndQueue(targetUserUri, currentUri);
           }
-        }, 2000);
+        });
+
+        // If autoplay was already enabled on load, queue a track
+        if (autoplayEnabled) {
+          const currentUri = Spicetify.Player.data?.item?.uri;
+          prefetchAndQueue(targetUserUri, currentUri);
+        }
 
         // Hotkeys with Alt
         document.addEventListener("keydown", async (e) => {
@@ -346,10 +437,26 @@ import random from "https://esm.sh/lodash.random";
             Spicetify.showNotification(
               `[Play Random] Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`,
             );
+            if (autoplayEnabled) {
+              const currentUri = Spicetify.Player.data?.item?.uri;
+              prefetchAndQueue(targetUserUri, currentUri);
+            } else {
+              if (queuedTrack) {
+                try {
+                  await Spicetify.removeFromQueue([{ uri: queuedTrack.uri }]);
+                } catch (e) {
+                  // Ignore
+                }
+                queuedTrack = null;
+              }
+            }
           }
 
           if (e.altKey && e.key === "r") {
-            await _PlayRandom.doTheThing(targetUserUri);
+            const result = await _PlayRandom.doTheThing(targetUserUri);
+            if (autoplayEnabled && result) {
+              prefetchAndQueue(targetUserUri, result.uri);
+            }
           }
 
           if (e.altKey && e.key === "e") {
@@ -366,6 +473,10 @@ import random from "https://esm.sh/lodash.random";
 
           const style = document.createElement("style");
           style.textContent = `
+#play-random-config {
+  max-height: none;
+  overflow: visible;
+}
 #play-random-config .setting-row {
   display: flex;
   justify-content: space-between;
@@ -406,19 +517,66 @@ import random from "https://esm.sh/lodash.random";
 }
 #play-random-config button.btn {
   font-weight: 700;
-  background-color: rgba(var(--spice-rgb-shadow), .7);
   border-radius: 500px;
   transition-duration: 33ms;
   transition-property: background-color, border-color, color, box-shadow, filter, transform;
   padding-inline: 15px;
   border: 1px solid #727272;
-  color: var(--spice-text);
   min-block-size: 32px;
   cursor: pointer;
 }
 #play-random-config button.btn:hover {
   transform: scale(1.04);
   border-color: var(--spice-text);
+}
+#play-random-config button.btn.save-btn {
+  background-color: var(--spice-button);
+  color: var(--spice-button-text, #000);
+  border-color: var(--spice-button);
+}
+#play-random-config button.btn.reset-btn {
+  background-color: rgba(var(--spice-rgb-shadow), .7);
+  color: var(--spice-text);
+}
+#play-random-config details {
+  margin-top: 16px;
+  border: 1px solid rgba(var(--spice-rgb-text), .15);
+  border-radius: 6px;
+  padding: 8px 12px;
+}
+#play-random-config details summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.875rem;
+  opacity: 0.8;
+  user-select: none;
+}
+#play-random-config details[open] summary {
+  margin-bottom: 8px;
+}
+#play-random-config .keybinding {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  font-size: 0.825rem;
+}
+#play-random-config .keybinding kbd {
+  background: rgba(var(--spice-rgb-shadow), .7);
+  border: 1px solid rgba(var(--spice-rgb-text), .2);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 0.8rem;
+  font-family: monospace;
+}
+#play-random-config .disclaimer {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: rgba(var(--spice-rgb-shadow), .4);
+  border-radius: 6px;
+  font-size: 0.775rem;
+  opacity: 0.7;
+  line-height: 1.4;
 }
 `;
 
@@ -440,6 +598,19 @@ import random from "https://esm.sh/lodash.random";
             Spicetify.showNotification(
               `[Play Random] Autoplay turned ${autoplayEnabled ? "ON" : "OFF"}`,
             );
+            if (autoplayEnabled) {
+              const currentUri = Spicetify.Player.data?.item?.uri;
+              prefetchAndQueue(targetUserUri, currentUri);
+            } else {
+              if (queuedTrack) {
+                try {
+                  Spicetify.removeFromQueue([{ uri: queuedTrack.uri }]);
+                } catch (e) {
+                  // Ignore
+                }
+                queuedTrack = null;
+              }
+            }
           };
 
           // --- Profile URI section ---
@@ -464,12 +635,24 @@ import random from "https://esm.sh/lodash.random";
           const buttonRow = document.createElement("div");
           Object.assign(buttonRow.style, {
             display: "flex",
-            gap: "8px",
+            justifyContent: "space-between",
             marginTop: "8px",
           });
 
+          const resetBtn = document.createElement("button");
+          resetBtn.className = "btn reset-btn";
+          resetBtn.textContent = "Reset to Default";
+          resetBtn.onclick = () => {
+            uriInput.value = DEFAULT_URI;
+            targetUserUri = DEFAULT_URI;
+            LocalStorage.set("play-random:user-uri", DEFAULT_URI);
+            Spicetify.showNotification(
+              "[Play Random] Reset to default profile.",
+            );
+          };
+
           const saveBtn = document.createElement("button");
-          saveBtn.className = "btn";
+          saveBtn.className = "btn save-btn";
           saveBtn.textContent = "Save";
           saveBtn.onclick = () => {
             let val = uriInput.value.trim();
@@ -494,20 +677,23 @@ import random from "https://esm.sh/lodash.random";
             }
           };
 
-          const resetBtn = document.createElement("button");
-          resetBtn.className = "btn";
-          resetBtn.textContent = "Reset to Default";
-          resetBtn.onclick = () => {
-            uriInput.value = DEFAULT_URI;
-            targetUserUri = DEFAULT_URI;
-            LocalStorage.set("play-random:user-uri", DEFAULT_URI);
-            Spicetify.showNotification(
-              "[Play Random] Reset to default profile.",
-            );
-          };
-
-          buttonRow.appendChild(saveBtn);
           buttonRow.appendChild(resetBtn);
+          buttonRow.appendChild(saveBtn);
+
+          // --- Keybindings ---
+          const keybindingsSection = document.createElement("details");
+          keybindingsSection.innerHTML = `
+<summary>Keyboard Shortcuts</summary>
+<div class="keybinding"><span>Play random song</span><kbd>Alt + R</kbd></div>
+<div class="keybinding"><span>Toggle autoplay</span><kbd>Alt + A</kbd></div>
+<div class="keybinding"><span>Open settings</span><kbd>Alt + E</kbd></div>
+`;
+
+          // --- Disclaimer ---
+          const disclaimer = document.createElement("div");
+          disclaimer.className = "disclaimer";
+          disclaimer.textContent =
+            "Heads up: For the smoothest autoplay experience, avoid rapidly skipping songs or manually adding tracks to your queue while autoplay is on. One random track is always queued up for you - skipping too fast may briefly play a non-random song before the next one loads.";
 
           configContainer.append(
             style,
@@ -516,10 +702,12 @@ import random from "https://esm.sh/lodash.random";
             uriInput,
             hintText,
             buttonRow,
+            keybindingsSection,
+            disclaimer,
           );
 
           Spicetify.PopupModal.display({
-            title: "Play Random — Settings",
+            title: "Play Random - Settings",
             content: configContainer,
           });
         }


### PR DESCRIPTION
# Overhaul Play Random: fix broken APIs, rewrite autoplay, add context menu

Major rework of `playRandom.mjs` - fixes broken playlist fetching, rewrites autoplay from scratch with queue injection, adds a settings modal, keyboard shortcuts, and a right-click context menu on user profiles.

**`play-random/playRandom.mjs`** | `+697 -208`

---

## What changed and why

<details>
<summary>🔧 Fixed / Migrated APIs</summary>

### Playlist fetching

The old `Spicetify.CosmosAsync` + public Spotify Web API combo was broken - returned incorrect or empty results, and had a bug where playlists under 50 were never randomised.

```diff
- const initialResponse = await Spicetify.CosmosAsync.get(
-   `https://api.spotify.com/v1/users/${userId}/playlists?limit=1`
- );
- const totalPlaylists = initialResponse.total;
- if (totalPlaylists <= 50) {
-   return { playlists: initialResponse, from: "lesser" };  // bug: never randomised
- } else if (totalPlaylists > 50) {
-   const randomOffset = random(totalPlaylists - 1);
-   const url = `https://api.spotify.com/v1/users/${userId}/playlists?limit=1&offset=${randomOffset}`;
-   const response = await Spicetify.CosmosAsync.get(url);
- }

+ const initialResponse = await Spicetify.Platform.RequestBuilder.build()
+   .withHost("https://spclient.wg.spotify.com/user-profile-view/v3")
+   .withPath(`/profile/${userId}/playlists`)
+   .withQueryParameters({ limit: 1, offset: 0 })
+   .send();
+ const totalPlaylists = initialResponse.body?.total_public_playlists_count || 0;
+ const randomOffset = random(totalPlaylists - 1);  // always randomised
```

### Track fetching from playlist

The old `sp://core-playlist/v1/playlist/` internal URI scheme stopped working entirely. Replaced with the platform `PlaylistAPI` which also provides `isPlayable` filtering.

```diff
- const res = await Spicetify.CosmosAsync.get(
-   `sp://core-playlist/v1/playlist/${uri}/rows`,
-   { policy: { link: true } }
- );
- return res.rows.map((item) => item.link);

+ const res = await Spicetify.Platform.PlaylistAPI.getContents(uri);
+ return res.items
+   .filter((track) => track.isPlayable)
+   .map((track) => track.uri);
```

### Track playability check

The old code used the public Web API's `preview_url` field as a proxy for playability, looping forever (`while (true)`) if the track wasn't playable:

```diff
- while (true) {
-   randomTrackUri = sample(trackUris);
-   const trackInfo = await Spicetify.CosmosAsync.get(
-     `https://api.spotify.com/v1/tracks/${randomTrackUri.split(":")[2]}`
-   );
-   if (trackInfo.preview_url) {  // unreliable playability check
-     break;
-   } else {
-     await new Promise((resolve) => setTimeout(resolve, 1000));  // infinite loop risk
-   }
- }

+ const { getTrack } = Spicetify.GraphQL.Definitions;
+ const trackData = await Spicetify.GraphQL.Request(getTrack, { uri: candidateUri });
+ if (trackData?.data?.trackUnion?.playability?.playable) {
+   // confirmed playable - use it
+ }
```

### Autoplay mechanism

Replaced `setInterval` polling + `Player.pause()` + `Player.playUri()` with event-driven `songchange` listener + `addToQueue`/`removeFromQueue`:

```diff
- // Old: polled every 2s, paused player, then played new track
- setInterval(async () => {
-   const progress = Spicetify.Player.getProgress();
-   const duration = Spicetify.Player.getDuration();
-   if (progress >= duration - 1000 && currentUri !== lastTrackUri) {
-     Spicetify.Player.pause();
-     await _PlayRandom.doTheThing(targetUserUri);
-   }
- }, 2000);

+ // New: pre-queue a track, detect when it plays via songchange
+ await Spicetify.addToQueue([{ uri: track.uri }]);
+ Spicetify.Player.addEventListener("songchange", async () => {
+   if (currentUri === queuedTrack.uri) {
+     // our track is playing - queue the next one
+     prefetchAndQueue(targetUserUri, playingUri);
+   }
+ });
```

### Settings persistence

Settings were lost on every reload. Now persisted via `Spicetify.LocalStorage`:

```diff
- let targetUserUri = "spotify:user:thesoundsofspotify";
- let autoplayEnabled = false;

+ let targetUserUri = LocalStorage.get("play-random:user-uri") || DEFAULT_URI;
+ let autoplayEnabled = LocalStorage.get("play-random:autoplay") === "true";
```

### API readiness check

Old code checked for `Spicetify.CosmosAsync` which no longer exists:

```diff
- while (
-   !((_a = Spicetify.Topbar) == null ? void 0 : _a.Button) ||
-   !((_b = Spicetify.PopupModal) == null ? void 0 : _b.display) ||
-   !Spicetify.CosmosAsync ||
-   !Spicetify.Playbar
- ) {

+ while (
+   !Spicetify.Topbar?.Button ||
+   !Spicetify.PopupModal?.display ||
+   !Spicetify.Playbar ||
+   !LocalStorage
+ ) {
```

### Summary table

| Old API / Pattern                                                                          | New API / Pattern                                                          | Why                                                           |
| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------- |
| `Spicetify.CosmosAsync.get("https://api.spotify.com/v1/users/...")`                        | `Spicetify.Platform.RequestBuilder.build().withHost().withPath().send()`   | CosmosAsync deprecated, public API requires auth tokens       |
| `Spicetify.CosmosAsync.get("sp://core-playlist/v1/playlist/.../rows")`                     | `Spicetify.Platform.PlaylistAPI.getContents(uri)`                          | `sp://core-*` internal URIs no longer resolve                 |
| `Spicetify.CosmosAsync.get("https://api.spotify.com/v1/tracks/...")` + `preview_url` check | `Spicetify.GraphQL.Request(getTrack, { uri })` + `playability.playable`    | `preview_url` is unreliable; GraphQL gives actual playability |
| `while (true)` loop retrying unplayable tracks                                             | Bounded retry (10 attempts per playlist, 3 playlists)                      | Infinite loop risk eliminated                                 |
| `setInterval(() => {...}, 2000)` polling progress/duration                                 | `Spicetify.Player.addEventListener("songchange", ...)`                     | Event-driven, no polling overhead                             |
| `Spicetify.Player.pause()` + `Spicetify.Player.playUri(uri)`                               | `Spicetify.addToQueue([{ uri }])` / `Spicetify.removeFromQueue([{ uri }])` | No abrupt cuts, seamless transitions                          |
| 3 separate `Topbar.Button`s (play, toggle, set profile)                                    | 1 `Topbar.Button` + right-click `PopupModal` settings                      | Cleaner UI, fewer topbar icons                                |
| No persistence (settings lost on reload)                                                   | `Spicetify.LocalStorage.get/set`                                           | Settings survive restarts                                     |
| No context menu                                                                            | `Spicetify.ContextMenu.SubMenu` + `Item` on `URI.isProfile`                | Right-click user profiles for quick actions                   |

</details>

<details>
<summary>🚀 Autoplay rewrite - queue injection</summary>

The old autoplay used `setInterval` polling every 2s to detect track end, then called `Player.pause()` + `Player.playUri()`, which caused:

- Abrupt cut of the current song mid-playback
- Unreliable end-of-track detection (polling missed fast skips)
- No pre-fetching (fetched only after the song ended, causing silence gaps)

The new model:

1. **Pre-fetches** a random track and immediately injects it into the queue via `Spicetify.addToQueue`
2. **Songchange listener** detects when the queued track starts playing, shows a toast, then pre-fetches the next one
3. If the user skips past the queued track, it stays in the queue - no re-queuing or removal on skip
4. Zero timing heuristics, zero progress listeners, zero race-prone flags

</details>

<details>
<summary>🔁 Playlist-level retries</summary>

`fetchRandomTrack` now retries up to **3 different playlists** if a playlist yields no playable tracks (empty, deleted, or restricted). Each playlist attempt allows up to 10 track sampling attempts with same-track deduplication.

```diff
+ const maxPlaylistAttempts = 3;
+ for (let playlistAttempt = 1; playlistAttempt <= maxPlaylistAttempts; playlistAttempt++) {
+   // ... fetch playlist, fetch tracks, sample ...
+   if (!trackUris || trackUris.length === 0) {
+     console.log(`[Play Random][PRE] Playlist attempt ${playlistAttempt}/${maxPlaylistAttempts}: No tracks, trying another`);
+     continue;
+   }
+ }
```

</details>

<details>
<summary>⚙️ Settings modal (right-click topbar button)</summary>

Right-clicking the topbar shuffle button now opens a styled settings modal with:

- **Autoplay toggle** - enables/disables continuous random playback with immediate effect
- **Profile URI input** - accepts both `spotify:user:<id>` format and `https://open.spotify.com/user/<id>` share links (auto-parsed)
- **Save / Reset to Default** buttons - persists to `Spicetify.LocalStorage`
- **Collapsible keyboard shortcuts** section (`<details>` / `<summary>`)
- **Disclaimer** about skip behaviour during autoplay

</details>

<details>
<summary>🖱️ Context menu on user profiles</summary>

Right-clicking any user profile in Spotify now shows a **"Play Random"** submenu (with shuffle icon) containing:

| Menu Item                 | Action                                                                        |
| ------------------------- | ----------------------------------------------------------------------------- |
| Play a random track       | Fetches and immediately plays a random song from the user's public playlists  |
| Queue a random track      | Silently fetches a random song and adds it to the queue                       |
| Set as randomiser profile | Saves the user as the target profile for autoplay, hotkeys, and topbar button |

The submenu only appears on user profile URIs (`Spicetify.URI.isProfile`).

</details>

<details>
<summary>🎹 Keyboard shortcuts</summary>

| Shortcut           | Action                 |
| ------------------ | ---------------------- |
| <kbd>Alt + R</kbd> | Play a random song     |
| <kbd>Alt + A</kbd> | Toggle autoplay on/off |
| <kbd>Alt + E</kbd> | Open settings modal    |

</details>

---

## Autoplay behaviour scenarios

| Scenario                                  | What happens                                                          |
| ----------------------------------------- | --------------------------------------------------------------------- |
| Autoplay ON, song ends naturally          | Queued random track plays → toast → next track pre-fetched and queued |
| Autoplay ON, user skips current song      | Queued track stays in queue, plays when reached                       |
| Autoplay ON, user skips past queued track | Queued track remains in queue (no removal, no re-queue)               |
| Autoplay ON, user manually queues songs   | Random track sits behind manual queue - no interference               |
| Autoplay ON, pre-fetch fails              | Retries on next songchange event                                      |
| Autoplay turned OFF                       | Queued random track removed from queue immediately                    |
| Autoplay ON at startup                    | Immediately pre-fetches and queues a track                            |
| Topbar button clicked (autoplay ON)       | Plays random song immediately, then pre-fetches next                  |
| Topbar button clicked (autoplay OFF)      | Plays random song, no pre-fetch                                       |

---

## Commits

```
feat(play-random): add context menu on user profiles
fix(play-random): avoid removing random song from queue on manual skip
feat(play-random): rewrite autoplay with queue injection and add playlist retries
feat(play-random): move auto-play and profile uri settings to right click settings
fix(play-random): migrate to new API for fetching playlists
fix(play-random): enhance error handling in PlayRandom
```
